### PR TITLE
Allow runtime configuration of widget fonts

### DIFF
--- a/displaywidget.lua
+++ b/displaywidget.lua
@@ -147,7 +147,7 @@ end
 function DisplayWidget:renderTimeWidget(now, width, font_face)
     return TextBoxWidget:new {
         text = self:getTimeText(now),
-        face = font_face or Font:getFace("infofont", 119),
+        face = font_face or Font:getFace("tfont", 119),
         width = width or Screen:getWidth(),
         alignment = "center",
         bold = true,

--- a/displaywidget.lua
+++ b/displaywidget.lua
@@ -149,7 +149,7 @@ end
 function DisplayWidget:renderTimeWidget(now, width, font_face)
     return TextBoxWidget:new {
         text = self:getTimeText(now),
-        face = font_face or Font:getFace("tfont", 119),
+        face = font_face or Font:getFace("infofont", 119),
         width = width or Screen:getWidth(),
         alignment = "center",
         bold = true,

--- a/displaywidget.lua
+++ b/displaywidget.lua
@@ -17,8 +17,7 @@ local T = require("ffi/util").template
 local _ = require("gettext")
 
 local DisplayWidget = InputContainer:extend {
-    on_dismiss = function()
-    end,
+    props = {},
 }
 
 function DisplayWidget:init()
@@ -72,7 +71,6 @@ function DisplayWidget:onSuspend()
 end
 
 function DisplayWidget:onTapClose()
-    self.on_dismiss()
     UIManager:unschedule(self.autoRefresh)
     UIManager:close(self)
 end
@@ -181,17 +179,26 @@ function DisplayWidget:render()
     self.time_widget = self:renderTimeWidget(
         self.now,
         screen_size.w,
-        Font:getFace("tfont", 119)
+        Font:getFace(
+            self.props.time_widget.font_name,
+            self.props.time_widget.font_size
+        )
     )
     self.date_widget = self:renderDateWidget(
         self.now,
         screen_size.w,
-        Font:getFace("largeffont"),
+        Font:getFace(
+            self.props.date_widget.font_name,
+            self.props.date_widget.font_size
+        ),
         true
     )
     self.status_widget = self:renderStatusWidget(
         screen_size.w,
-        Font:getFace("infofont")
+        Font:getFace(
+            self.props.status_widget.font_name,
+            self.props.status_widget.font_size
+        )
     )
 
     -- Compute the widget heights and the amount of spacing we need

--- a/main.lua
+++ b/main.lua
@@ -47,6 +47,16 @@ function DtDisplay:getFontMenuList()
     cre = require("document/credocument"):engineInit()
     local face_list = cre.getFontFaces()
     local menu_list = {}
+
+    -- Font size
+    table.insert(menu_list, {
+        text_func = function()
+            return _("Font size: ")
+        end,
+        separator = true
+    })
+
+    -- Font list
     for k, v in ipairs(face_list) do
         local font_filename, font_faceindex, is_monospace = cre.getFontFaceFilenameAndFaceIndex(v)
         table.insert(menu_list, {

--- a/main.lua
+++ b/main.lua
@@ -1,6 +1,8 @@
 local DisplayWidget = require("displaywidget")
+local DataStorage = require("datastorage")
 local Font = require("ui/font")
 local FontList = require("fontlist")
+local LuaSettings = require("frontend/luasettings")
 local UIManager = require("ui/uimanager")
 local WidgetContainer = require("ui/widget/container/widgetcontainer")
 local cre -- delayed loading
@@ -9,26 +11,40 @@ local T = require("ffi/util").template
 
 local DtDisplay = WidgetContainer:extend {
     name = "dtdisplay",
+    config_file = "dtdisplay_config.lua",
+    local_storage = nil,
     is_doc_only = false,
 }
 
 function DtDisplay:init()
-    self.settings = {
-        date_widget = {
-            font_name = "",
-            font_size = 25,
-        },
-        time_widget = {
-            font_name = "",
-            font_size = 119,
-        },
-        status_widget = {
-            font_name = "",
-            font_size = 24,
-        },
-    }
+    local logger = require("logger")
+    logger.dbg("SDKLFJSDKLFJSDKLFJKLSDJLK settings dir", ("%s/%s"):format(DataStorage:getSettingsDir(), self.config_file))
 
+    self:initLuaSettings()
+
+    self.settings = self.local_storage.data
     self.ui.menu:registerToMainMenu(self)
+end
+
+function DtDisplay:initLuaSettings()
+    self.local_storage = LuaSettings:open(("%s/%s"):format(DataStorage:getSettingsDir(), self.config_file))
+    if next(self.local_storage.data) == nil then
+        self.local_storage:reset({
+            date_widget = {
+                font_name = "./fonts/noto/NotoSans-Regular.ttf",
+                font_size = 25,
+            },
+            time_widget = {
+                font_name = "./fonts/noto/NotoSans-Regular.ttf",
+                font_size = 119,
+            },
+            status_widget = {
+                font_name = "./fonts/noto/NotoSans-Regular.ttf",
+                font_size = 24,
+            },
+        })
+        self.local_storage:flush()
+    end
 end
 
 function DtDisplay:addToMainMenu(menu_items)
@@ -179,26 +195,38 @@ end
 
 function DtDisplay:setDateFont(font)
     self.settings["date_widget"]["font_name"] = font
+    self.local_storage:reset(self.settings)
+    self.local_storage:flush()
 end
 
 function DtDisplay:setTimeFont(font)
     self.settings["time_widget"]["font_name"] = font
+    self.local_storage:reset(self.settings)
+    self.local_storage:flush()
 end
 
 function DtDisplay:setStatuslineFont(font)
     self.settings["status_widget"]["font_name"] = font
+    self.local_storage:reset(self.settings)
+    self.local_storage:flush()
 end
 
 function DtDisplay:setDateFontSize(font_size)
     self.settings["date_widget"]["font_size"] = font_size
+    self.local_storage:reset(self.settings)
+    self.local_storage:flush()
 end
 
 function DtDisplay:setTimeFontSize(font_size)
     self.settings["time_widget"]["font_size"] = font_size
+    self.local_storage:reset(self.settings)
+    self.local_storage:flush()
 end
 
 function DtDisplay:setStatuslineFontSize(font_size)
     self.settings["status_widget"]["font_size"] = font_size
+    self.local_storage:reset(self.settings)
+    self.local_storage:flush()
 end
 
 function DtDisplay:showDateTimeWidget()

--- a/main.lua
+++ b/main.lua
@@ -242,7 +242,7 @@ function DtDisplay:showFontSizeSpinWidget(touchmenu_instance, font_size, callbac
             value_min = 8,
             value_max = 256,
             value_step = 1,
-            value_hold_step = 5,
+            value_hold_step = 10,
             ok_text = _("Set font size"),
             title_text = _("Set font size"),
             callback = function(spin)

--- a/main.lua
+++ b/main.lua
@@ -1,4 +1,6 @@
 local DisplayWidget = require("displaywidget")
+local Font = require("ui/font")
+local FontList = require("fontlist")
 local UIManager = require("ui/uimanager")
 local WidgetContainer = require("ui/widget/container/widgetcontainer")
 local _ = require("gettext")
@@ -16,10 +18,79 @@ function DtDisplay:addToMainMenu(menu_items)
     menu_items.dtdisplay = {
         text = _("Time & Day"),
         sorting_hint = "more_tools",
-        callback = function()
-            UIManager:show(DisplayWidget:new {})
-        end,
+        sub_item_table = {
+            {
+                text = _("Launch"),
+                separator = true,
+                callback = function()
+                    UIManager:show(DisplayWidget:new {})
+                end,
+            },
+            {
+                text = _("Date widget font"),
+                sub_item_table = self:getFontMenuList(),
+            },
+            {
+                text = _("Time widget font"),
+                sub_item_table = self:getFontMenuList(),
+            },
+            {
+                text = _("Status line font"),
+                sub_item_table = self:getFontMenuList(),
+            }
+        },
     }
+end
+
+function DtDisplay:getFontMenuList()
+    -- Based on readerfont.lua
+    cre = require("document/credocument"):engineInit()
+    local face_list = cre.getFontFaces()
+    local menu_list = {}
+    for k, v in ipairs(face_list) do
+        local font_filename, font_faceindex, is_monospace = cre.getFontFaceFilenameAndFaceIndex(v)
+        table.insert(menu_list, {
+            text_func = function()
+                -- defaults are hardcoded in credocument.lua
+                local default_font = G_reader_settings:readSetting("cre_font")
+                local fallback_font = G_reader_settings:readSetting("fallback_font")
+                local monospace_font = G_reader_settings:readSetting("monospace_font")
+                local text = v
+                if font_filename and font_faceindex then
+                    text = FontList:getLocalizedFontName(font_filename, font_faceindex) or text
+                end
+
+                if v == monospace_font then
+                    text = text .. " \u{1F13C}" -- Squared Latin Capital Letter M
+                elseif is_monospace then
+                    text = text .. " \u{1D39}"  -- Modified Letter Capital M
+                end
+                if v == default_font then
+                    text = text .. "   ★"
+                end
+                if v == fallback_font then
+                    text = text .. "   �"
+                end
+                return text
+            end,
+            font_func = function(size)
+                if G_reader_settings:nilOrTrue("font_menu_use_font_face") then
+                    if font_filename and font_faceindex then
+                        return Font:getFace(font_filename, size, font_faceindex)
+                    end
+                end
+            end,
+            callback = function()
+            end,
+            hold_callback = function(touchmenu_instance)
+            end,
+            checked_func = function()
+            end,
+            menu_item_id = v,
+        })
+    end
+
+    return menu_list
 end
 
 return DtDisplay

--- a/main.lua
+++ b/main.lua
@@ -17,9 +17,6 @@ local DtDisplay = WidgetContainer:extend {
 }
 
 function DtDisplay:init()
-    local logger = require("logger")
-    logger.dbg("SDKLFJSDKLFJSDKLFJKLSDJLK settings dir", ("%s/%s"):format(DataStorage:getSettingsDir(), self.config_file))
-
     self:initLuaSettings()
 
     self.settings = self.local_storage.data

--- a/main.lua
+++ b/main.lua
@@ -16,15 +16,15 @@ function DtDisplay:init()
     self.settings = {
         date_widget = {
             font_name = "",
-            font_size = 123,
+            font_size = 25,
         },
         time_widget = {
             font_name = "",
-            font_size = 123,
+            font_size = 119,
         },
         status_widget = {
             font_name = "",
-            font_size = 123,
+            font_size = 24,
         },
     }
 
@@ -40,7 +40,7 @@ function DtDisplay:addToMainMenu(menu_items)
                 text = _("Launch"),
                 separator = true,
                 callback = function()
-                    UIManager:show(DisplayWidget:new {})
+                    UIManager:show(DisplayWidget:new { props = self.settings })
                 end,
             },
             {
@@ -163,12 +163,12 @@ function DtDisplay:getFontMenuList(args)
                 end
             end,
             callback = function()
-                return font_callback(v)
+                return font_callback(font_filename)
             end,
             hold_callback = function(touchmenu_instance)
             end,
             checked_func = function()
-                return checked_func(v)
+                return checked_func(font_filename)
             end,
             menu_item_id = v,
         })

--- a/main.lua
+++ b/main.lua
@@ -14,12 +14,18 @@ local DtDisplay = WidgetContainer:extend {
 
 function DtDisplay:init()
     self.settings = {
-        date_font_size = 123,
-        time_font_size = 123,
-        statusline_font_size = 123,
-        date_font_name = "",
-        time_font_name = "",
-        statusline_font_name = ""
+        date_widget = {
+            font_name = "",
+            font_size = 123,
+        },
+        time_widget = {
+            font_name = "",
+            font_size = 123,
+        },
+        status_widget = {
+            font_name = "",
+            font_size = 123,
+        },
     }
 
     self.ui.menu:registerToMainMenu(self)
@@ -44,7 +50,7 @@ function DtDisplay:addToMainMenu(menu_items)
                         self:setDateFont(font_name)
                     end,
                     function(font)
-                        return font == self.settings["date_font_name"]
+                        return font == self.settings.date_widget.font_name
                     end
                 ),
             },
@@ -55,7 +61,7 @@ function DtDisplay:addToMainMenu(menu_items)
                         self:setTimeFont(font_name)
                     end,
                     function(font)
-                        return font == self.settings["time_font_name"]
+                        return font == self.settings.time_widget.font_name
                     end
                 ),
             },
@@ -66,7 +72,7 @@ function DtDisplay:addToMainMenu(menu_items)
                         self:setStatuslineFont(font_name)
                     end,
                     function(font)
-                        return font == self.settings["statusline_font_name"]
+                        return font == self.settings.status_widget.font_name
                     end
                 ),
             }
@@ -138,15 +144,15 @@ function DtDisplay:getFontMenuList(callback, checked_func)
 end
 
 function DtDisplay:setDateFont(font)
-    self.settings["date_font_name"] = font
+    self.settings["date_widget"]["font_name"] = font
 end
 
 function DtDisplay:setTimeFont(font)
-    self.settings["time_font_name"] = font
+    self.settings["time_widget"]["font_name"] = font
 end
 
 function DtDisplay:setStatuslineFont(font)
-    self.settings["statusline_font_name"] = font
+    self.settings["status_widget"]["font_name"] = font
 end
 
 return DtDisplay

--- a/main.lua
+++ b/main.lua
@@ -3,7 +3,9 @@ local Font = require("ui/font")
 local FontList = require("fontlist")
 local UIManager = require("ui/uimanager")
 local WidgetContainer = require("ui/widget/container/widgetcontainer")
+local cre -- delayed loading
 local _ = require("gettext")
+
 
 local DtDisplay = WidgetContainer:extend {
     name = "dtdisplay",
@@ -11,6 +13,15 @@ local DtDisplay = WidgetContainer:extend {
 }
 
 function DtDisplay:init()
+    self.settings = {
+        date_font_size = 123,
+        time_font_size = 123,
+        statusline_font_size = 123,
+        date_font_name = "",
+        time_font_name = "",
+        statusline_font_name = ""
+    }
+
     self.ui.menu:registerToMainMenu(self)
 end
 
@@ -28,21 +39,42 @@ function DtDisplay:addToMainMenu(menu_items)
             },
             {
                 text = _("Date widget font"),
-                sub_item_table = self:getFontMenuList(),
+                sub_item_table = self:getFontMenuList(
+                    function(font_name)
+                        self:setDateFont(font_name)
+                    end,
+                    function(font)
+                        return font == self.settings["date_font_name"]
+                    end
+                ),
             },
             {
                 text = _("Time widget font"),
-                sub_item_table = self:getFontMenuList(),
+                sub_item_table = self:getFontMenuList(
+                    function(font_name)
+                        self:setTimeFont(font_name)
+                    end,
+                    function(font)
+                        return font == self.settings["time_font_name"]
+                    end
+                ),
             },
             {
                 text = _("Status line font"),
-                sub_item_table = self:getFontMenuList(),
+                sub_item_table = self:getFontMenuList(
+                    function(font_name)
+                        self:setStatuslineFont(font_name)
+                    end,
+                    function(font)
+                        return font == self.settings["statusline_font_name"]
+                    end
+                ),
             }
         },
     }
 end
 
-function DtDisplay:getFontMenuList()
+function DtDisplay:getFontMenuList(callback, checked_func)
     -- Based on readerfont.lua
     cre = require("document/credocument"):engineInit()
     local face_list = cre.getFontFaces()
@@ -91,16 +123,30 @@ function DtDisplay:getFontMenuList()
                 end
             end,
             callback = function()
+                return callback(v)
             end,
             hold_callback = function(touchmenu_instance)
             end,
             checked_func = function()
+                return checked_func(v)
             end,
             menu_item_id = v,
         })
     end
 
     return menu_list
+end
+
+function DtDisplay:setDateFont(font)
+    self.settings["date_font_name"] = font
+end
+
+function DtDisplay:setTimeFont(font)
+    self.settings["time_font_name"] = font
+end
+
+function DtDisplay:setStatuslineFont(font)
+    self.settings["statusline_font_name"] = font
 end
 
 return DtDisplay


### PR DESCRIPTION
## Background

Allow users to configure the font and font sizes of each of the lines in the widget. This allows users to customize their digital clock display to their liking, using any font in their font library.

## Discussion

Settings are persisted using the LuaSettings module provided by koreader. Settings are persisted in `koreader/settings/dtdisplay_config.lua`. These changes do not make use of LuaSetting's accessors and mutators, with most of the state management managed by the plugin internally; LuaSettings is only used to persist an arbitrary table with arbitrary shape.

## Testing

Linux appimage 2023.03

## Screenshots

| Description | Screenshot |
| --- | --- |
| Main menu |  ![image](https://user-images.githubusercontent.com/4438551/233498195-2452c138-3dbd-4584-8bdc-2b1079e050ba.png) |
| Font menu | ![image](https://user-images.githubusercontent.com/4438551/233498302-59cfcf06-a50d-4140-bf79-da3ca2cf0c14.png) |
| Font size | ![image](https://user-images.githubusercontent.com/4438551/233498359-c8dd5b07-8aea-4a45-9a98-b6b8c15bbe4c.png) |
| Customized widget | ![image](https://user-images.githubusercontent.com/4438551/233498533-5e1fe2ed-8949-493c-bdb4-8ff1015d4e7d.png) |


